### PR TITLE
Gruntwithoutimg

### DIFF
--- a/grunt/aliases.coffee
+++ b/grunt/aliases.coffee
@@ -70,7 +70,7 @@ module.exports =
   ]
 
   assets: [
-    "newer:imagemin"
+    "newer:copy:images"
     "copy:fonts"
     "copy:video"
   ]

--- a/grunt/copy.coffee
+++ b/grunt/copy.coffee
@@ -6,10 +6,10 @@ module.exports =
     dest: "dev/"
 
   css:
-   expand: true
-   cwd: "dev"
-   src: "styles/**/*.{css,scss}"
-   dest: "dev/"
+    expand: true
+    cwd: "dev"
+    src: "styles/**/*.{css,scss}"
+    dest: "dev/"
 
   html:
     expand: true
@@ -29,6 +29,13 @@ module.exports =
     cwd: "src"
     src: "api/**/*.json"
     dest: "dev/api"
+
+  images:
+    expand: true
+    flatten: true
+    cwd: "src"
+    src: "images/**/*.*"
+    dest: "dev/images"
 
   fonts:
     expand: true


### PR DESCRIPTION
Significantly lowered load time by removing img-min
